### PR TITLE
Fix GTK 2/3 vs GTK 4 crash on GNOME

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = replay-bin
 	pkgdesc = Replay - UI for generating songs with AI singers, RVC training and speech conversion. Offline, local, and free.
 	pkgver = 8.7.0
-	pkgrel = 2
+	pkgrel = 3
 	url = https://github.com/KylerianHD/replay-bin
 	arch = x86_64
 	license = GPL3 OR unknown

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: KylerianHD (aka ToxicByte) <contact@kylerianhd.com>
 pkgname=replay-bin
 pkgver=8.7.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Replay - UI for generating songs with AI singers, RVC training and speech conversion. Offline, local, and free."
 arch=('x86_64')
 url="https://github.com/KylerianHD/replay-bin"
@@ -48,9 +48,17 @@ package() {
   tar -xJf data.tar.xz -C "$pkgdir"
 
   # 2) Launcher stub in /usr/bin
-  install -Dm755 /dev/stdin "$pkgdir/usr/bin/replay" <<EOF
+  # Pass --gtk-version=3 on GNOME to avoid GTK 2/3 vs GTK 4 symbol conflict
+  install -Dm755 /dev/stdin "$pkgdir/usr/bin/replay" <<'EOF'
 #!/bin/sh
-exec /opt/Replay/replay "\$@"
+case "$XDG_CURRENT_DESKTOP" in
+  *GNOME*)
+    exec /opt/Replay/replay --gtk-version=3 "$@"
+    ;;
+  *)
+    exec /opt/Replay/replay "$@"
+    ;;
+esac
 EOF
 
   # 3) .desktop file


### PR DESCRIPTION
Fixes #1.

## What changed

Updated the `/usr/bin/replay` launcher stub to detect GNOME via `$XDG_CURRENT_DESKTOP` and automatically pass `--gtk-version=3` to the Electron binary.

```sh
case "$XDG_CURRENT_DESKTOP" in
  *GNOME*)
    exec /opt/Replay/replay --gtk-version=3 "$@"
    ;;
  *)
    exec /opt/Replay/replay "$@"
    ;;
esac
```

The `*GNOME*` glob covers `GNOME`, `ubuntu:GNOME`, and similar variants. Non-GNOME desktops are completely unaffected.

Also bumped `pkgrel` to 3 and regenerated `.SRCINFO`.